### PR TITLE
Решение проблемы с test-report. Обновление путей в yml файлах

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,4 +36,4 @@ jobs:
         if: success() || failure()
         with:
           name: test-results
-          path: HomeWork*/Hw*Tests/TestResults/*.trx
+          path: Homework*/Hw*.Tests/TestResults/*.trx

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -12,5 +12,5 @@ jobs:
       with:
         artifact: test-results            # artifact name
         name: test-report                  # Name of the check run which will be created
-        path: 'HomeWork*/Hw*Tests/TestResults/*.trx'                     # Path to test results (inside artifact .zip)
+        path: 'Homework*/Hw*.Tests/TestResults/*.trx'                     # Path to test results (inside artifact .zip)
         reporter: dotnet-trx              # Format of test results


### PR DESCRIPTION
Из-за того что были изменены названия файлов, сломались workflow отвечающие за тесты.
Обновил пути до актуальных.